### PR TITLE
fix: corrected typo for rest_api result name

### DIFF
--- a/bws/calc/calcs.py
+++ b/bws/calc/calcs.py
@@ -128,7 +128,7 @@ class Predictions():
             elif ry is not None:
                 self.ten_yr_nhs_protocol = ry
         if mp is not None:
-            self.mutation_probabilties = mp
+            self.mutation_probabilities = mp
 
         # remaining lifetime baseline
         if rr is not None:

--- a/bws/rest_api.py
+++ b/bws/rest_api.py
@@ -152,7 +152,7 @@ class ModelWebServiceMixin(APIView):
                         this_pedigree["prs"] = {'alpha': prs.alpha, 'zscore': prs.zscore}
                     this_pedigree["mutation_frequency"] = {this_params.population: this_params.mutation_frequency}
                     self.add_attr("version", output, calcs, output)
-                    self.add_attr("mutation_probabilties", this_pedigree, calcs, output)
+                    self.add_attr("mutation_probabilities", this_pedigree, calcs, output)
                     self.add_attr("cancer_risks", this_pedigree, calcs, output)
                     self.add_attr("baseline_cancer_risks", this_pedigree, calcs, output)
                     self.add_attr("lifetime_cancer_risk", this_pedigree, calcs, output)

--- a/bws/scripts/run_webservice.py
+++ b/bws/scripts/run_webservice.py
@@ -70,9 +70,9 @@ def post_requests(url, **kwargs):
 
 def mutation_probability_output(res, writer):
     ''' Write out mutation carrier probabilities '''
-    if 'mutation_probabilties' in res:
-        writer.writerow(['Mutation Carrier Probabilties'])
-        muts = res['mutation_probabilties']
+    if 'mutation_probabilities' in res:
+        writer.writerow(['Mutation Carrier probabilities'])
+        muts = res['mutation_probabilities']
         col = ['FamID']
         val = [res['family_id']]
         for m in muts:

--- a/bws/serializers.py
+++ b/bws/serializers.py
@@ -120,7 +120,7 @@ class PedigreeResultSerializer(serializers.Serializer):
     ten_yr_cancer_risk = serializers.ListField(read_only=True, required=False, help_text="10 year age range risks")
     baseline_ten_yr_cancer_risk = serializers.ListField(read_only=True, required=False, help_text="Baseline/population 10 year age range risks")
     ten_yr_nhs_protocol = serializers.ListField(read_only=True, required=False, help_text="NHS protocol 10 year breast cancer risks")
-    mutation_probabilties = serializers.ListField(read_only=True, help_text="Pathogenic variant carrier probability")
+    mutation_probabilities = serializers.ListField(read_only=True, help_text="Pathogenic variant carrier probability")
 
 
 class OutputSerializer(serializers.Serializer):

--- a/bws/tests/test_pws.py
+++ b/bws/tests/test_pws.py
@@ -97,7 +97,7 @@ class PwsTests(TestCase):
         content = json.loads(force_str(response.content))
         self.assertTrue("pedigree_result" in content)
         self.assertTrue('cancer_risks not provided' in content['warnings'])
-        self.assertTrue('mutation_probabilties' in content['pedigree_result'][0])
+        self.assertTrue('mutation_probabilities' in content['pedigree_result'][0])
 
     def test_pws_err(self):
         ''' Test error with an invalid gene test resuly. '''

--- a/bws/tests/tests_pedigree.py
+++ b/bws/tests/tests_pedigree.py
@@ -91,10 +91,10 @@ class RiskTests(TestCase):
         calcs = Predictions(pedigree, cwd=self.cwd)
 
         # each gene should have a mutation probability plus a result for no mutations
-        for mp in calcs.mutation_probabilties:
+        for mp in calcs.mutation_probabilities:
             key = list(mp.keys())[0]
             self.assertTrue(key in settings.BC_MODEL['GENES'] or key == "no mutation")
-        self.assertEqual(len(calcs.mutation_probabilties), len(settings.BC_MODEL['GENES']) + 1)
+        self.assertEqual(len(calcs.mutation_probabilities), len(settings.BC_MODEL['GENES']) + 1)
 
         # risks calculated at 16 different ages:
         self.assertEqual(len(calcs.cancer_risks), 16)
@@ -132,10 +132,10 @@ class RiskTests(TestCase):
         calcs = Predictions(pedigree, cwd=self.cwd)
 
         # each gene should have a mutation probability plus a result for no mutations
-        for mp in calcs.mutation_probabilties:
+        for mp in calcs.mutation_probabilities:
             key = list(mp.keys())[0]
             self.assertTrue(key in settings.BC_MODEL['GENES'] or key == "no mutation")
-        self.assertEqual(len(calcs.mutation_probabilties), len(settings.BC_MODEL['GENES']) + 1)
+        self.assertEqual(len(calcs.mutation_probabilities), len(settings.BC_MODEL['GENES']) + 1)
 
         # risks calculated at different ages:
         self.assertEqual(len(calcs.cancer_risks), 9)
@@ -157,10 +157,10 @@ class RiskTests(TestCase):
                             model_settings=settings.OC_MODEL, calcs=[])
 
         # each gene should have a mutation probability plus a result for no mutations
-        for mp in calcs.mutation_probabilties:
+        for mp in calcs.mutation_probabilities:
             key = list(mp.keys())[0]
             self.assertTrue(key in settings.OC_MODEL['GENES'] or key == "no mutation")
-        self.assertEqual(len(calcs.mutation_probabilties), len(settings.OC_MODEL['GENES']) + 1)
+        self.assertEqual(len(calcs.mutation_probabilities), len(settings.OC_MODEL['GENES']) + 1)
 
         # risks calculated at 16 different ages:
         self.assertEqual(len(calcs.cancer_risks), 16)
@@ -228,7 +228,7 @@ class RiskTests(TestCase):
             calcs = Predictions(pedigree, cwd=self.cwd, model_params=params)
 
             # each gene should have a mutation probability plus a result for no mutations
-            self.assertEqual(len(calcs.mutation_probabilties), len(settings.BC_MODEL['GENES']) + 1)
+            self.assertEqual(len(calcs.mutation_probabilities), len(settings.BC_MODEL['GENES']) + 1)
 
             # risks calculated at different ages:
             self.assertTrue([c.get('age') for c in calcs.cancer_risks] ==
@@ -269,7 +269,7 @@ class RiskTests(TestCase):
             calcs = Predictions(pedigree, cwd=self.cwd, model_params=params)
 
             # each gene should have a mutation probability plus a result for no mutations
-            self.assertEqual(len(calcs.mutation_probabilties), len(settings.BC_MODEL['GENES']) + 1)
+            self.assertEqual(len(calcs.mutation_probabilities), len(settings.BC_MODEL['GENES']) + 1)
 
             # risks calculated at different ages:
             self.assertTrue([c.get('age') for c in calcs.cancer_risks] ==


### PR DESCRIPTION
Hello, when trying to parse the output of the `boadicea` REST API call i noticed that one of the fields is misspelled, I know that it's not a big issue and probabily also a pain for whomever already uses it and parses it already, but I've gone ahead and changed it with the proper spelling: `mutation_probabilties` becomes `mutation_probabilities` (added the missing *i* character in `probabil *i* ties`).

As I said, I don't know if it will be changed but just in case I wanted at least to bring it up and propose the fixed.
